### PR TITLE
Made it buildable on Haskell Platform 2014.2.0.0 by default.

### DIFF
--- a/whiskers.cabal
+++ b/whiskers.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.8
 library
   exposed-modules:     Text.Whiskers
   -- other-modules:       
-  build-depends:       base ==4.6.*, template-haskell ==2.8.*, parsec ==3.1.*
+  build-depends:       base >= 4.6 && < 4.8, template-haskell >= 2.8 && < 2.10, parsec == 3.1.*
 
 source-repository head
   type:     git


### PR DESCRIPTION
Prior to this commit one would have to manually edit the _.cabal_ file to be able to build this on the most recent Haskell Platform. This expands the bounds of `base` and `template-haskell` to be usable on Haskell Platform version 2014.2.0.0.
